### PR TITLE
Cache plugins to a data controller.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
     "presets": ["env"],
     "plugins": [
-        "babel-plugin-inline-import"
+        "babel-plugin-inline-import",
+        "transform-class-properties"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-inline-import": "^2.0.6",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.0"
   }
 }

--- a/src/poc/CacheLocal.js
+++ b/src/poc/CacheLocal.js
@@ -1,0 +1,22 @@
+import { CachePluginBase } from './CachePluginBase';
+
+export class CacheLocal extends CachePluginBase {
+  constructor() {
+    super();
+    this.cache = {};
+  }
+
+  set(id, data) {
+    this.cache[id] = data;
+    return this;
+  }
+
+  get(id) {
+    if (!this.cache[id]) {
+      this.cache[id] = null;
+    }
+    return this.cache[id];
+  }
+}
+
+export default () => new CacheLocal;

--- a/src/poc/CachePluginBase.js
+++ b/src/poc/CachePluginBase.js
@@ -1,0 +1,14 @@
+
+export class CachePluginBase {
+  set(id, data) {
+    console.log('This plugin has not implemented the set method');
+    return this;
+  }
+
+  get(id) {
+    console.log('This plugin has not implemented the get method.');
+    return null;
+  }
+}
+
+export default () => new CachePluginBase();

--- a/src/poc/DataControllerBase.js
+++ b/src/poc/DataControllerBase.js
@@ -1,0 +1,26 @@
+
+import CachePluginBase from './CachePluginBase';
+
+class DataControllerBase {
+
+  cachePlugin = CachePluginBase;
+
+  getCachePlugin() {
+    if (!this.cache) {
+      this.cache = new this.cachePlugin;
+    }
+    return this.cache;
+  }
+
+  setCache(id, data) {
+    this.getCachePlugin().set(id, data);
+    return this;
+  }
+
+  getCache(id) {
+    return this.getCachePlugin().get(id);
+  }
+
+}
+
+export default DataControllerBase;

--- a/src/poc/MarvelApiController.js
+++ b/src/poc/MarvelApiController.js
@@ -1,0 +1,72 @@
+import crypto from 'crypto';
+import fetch from 'node-fetch';
+import DataControllerBase from './DataControllerBase';
+import CacheLocal from './CacheLocal';
+
+// Import classes to assist with formatting the API response into a structure
+// that represents the GraphQL Schema for the type in the graphql server.
+import { Model as Comic } from '../types/comic';
+
+/**
+---- ENVIRONMENT VARIABLES ----
+dotenv stores configuration variables in a local .env file. This allows us to
+store API credentials locally and rely on environment variables in production
+to store important credentials.
+
+dotenv will not override environment defined variables with those in the file.
+
+@see https://github.com/motdotla/dotenv
+@see https://github.com/motdotla/dotenv/issues/133#issuecomment-321779690
+*/
+
+class MarvelApiController extends DataControllerBase {
+
+  cachePlugin = CacheLocal;
+
+  constructor() {
+    super();
+    const privateKey = process.env.API_PRIVATE_KEY;
+    const publicKey = process.env.API_PUBLIC_KEY;
+
+    const ts = Date.now();
+    const hash = crypto.createHash('md5').update(`${ts}${privateKey}${publicKey}`).digest('hex');
+
+    this.url = 'http://gateway.marvel.com/v1/public';
+    this.params = `ts=${ts}&apikey=${publicKey}&hash=${hash}`;
+  }
+
+  handleErrors(error) {
+    console.log(error);
+  }
+
+  characters() {
+    const url = `${this.url}/characters?${this.params}`;
+
+    return fetch(url)
+      .then(res => res.json())
+      .then()
+      .catch(this.handleErrors);
+  }
+
+  comics(id) {
+    const url = `${this.url}/characters/${id}/comics?${this.params}`;
+
+    if (this.getCache(`comics.${id}`)) {
+      return this.getCache(`comics.${id}`);
+    }
+
+    return fetch(url)
+      .then(res => res.json())
+      .then(json => {
+        const comics = json.data.results.map(i => new Comic(i));
+        this.setCache(`comics.${id}`, comics);
+        return comics;
+      })
+      .catch(() => this.getCache(`comics.${id}`));
+  }
+
+}
+
+// This is the singleton pattern for NodeJS - this will allow all types to use
+// the same instance of MarvelApi.
+export let api = new MarvelApiController();

--- a/src/types/hero.js
+++ b/src/types/hero.js
@@ -1,6 +1,6 @@
 import heroesList from '../../data/heroes'
 import villainList from '../../data/villains';
-import { api as MarvelApi } from '../helper/MarvelApi';
+import { api as MarvelApi } from '../poc/MarvelApiController';
 
 import villains from './villain';
 import comics from './comic';

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,6 +340,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -355,6 +359,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
- Data controller instructs the application on how to fetch data from an
endpoint. The data controller can specify which cache backend it wants
to use for the requests.
- Adds a simple interface for cache plugins.
- Adds a simple interface for the data controllers.
- Adds a marvel api data controller.